### PR TITLE
feat(dashboard): implement setup wizard for first-time users

### DIFF
--- a/docs/plan/12-setup-wizard/00-issue-context.md
+++ b/docs/plan/12-setup-wizard/00-issue-context.md
@@ -1,0 +1,49 @@
+# Issue #12: DASH-002 - Setup Wizard for Non-Technical Users
+
+## Overview
+
+**Goal:** Guide new users through setting up their first CDC pipeline with a step-by-step wizard, achieving "time to value" under 10 minutes.
+
+**Problem:** First-time users face a learning curve - concepts like sources, replication slots, and table mappings need explanation. The wizard abstracts these into simple questions.
+
+**Who Benefits:**
+- First-time users getting started
+- Non-technical users needing guidance
+- Teams evaluating Philotes
+
+## Wizard Steps
+
+1. **Welcome & overview** - Introduction to CDC and what they'll accomplish
+2. **Connect source database** - Database credentials with connection test
+3. **Select tables to replicate** - Table browser with search and select
+4. **Configure destination settings** - Smart defaults with optional customization
+5. **Review and create pipeline** - Summary before creation
+6. **Watch first sync complete** - Success celebration with next steps
+
+## Acceptance Criteria
+
+- [ ] Multi-step form with progress indicator
+- [ ] Database connection wizard with test button
+- [ ] Table browser with search and select
+- [ ] Configuration recommendations (smart defaults)
+- [ ] Real-time validation at each step
+- [ ] Success celebration with next steps
+
+## Dependencies
+
+- DASH-001 (Dashboard Framework) - Completed
+
+## Blocks
+
+- INSTALL-004 (Post-Installation Setup Wizard) - Shares wizard components
+
+## Labels
+
+- `epic:dashboard`
+- `phase:mvp`
+- `priority:medium`
+- `type:feature`
+
+## Milestone
+
+M2: Management Layer

--- a/docs/plan/12-setup-wizard/01-research.md
+++ b/docs/plan/12-setup-wizard/01-research.md
@@ -1,0 +1,139 @@
+# Research Findings - Issue #12: Setup Wizard
+
+## 1. Existing API Endpoints
+
+### Source Management (`/api/v1/sources`)
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/sources` | POST | Create source |
+| `/sources/:id` | GET | Get source details |
+| `/sources/:id/test` | POST | Test connection |
+| `/sources/:id/tables` | GET | Discover tables |
+
+**CreateSourceRequest:**
+```typescript
+{
+  name: string              // Required: 1-255 chars
+  type: "postgresql"        // Defaults to "postgresql"
+  host: string              // Required
+  port: number              // Defaults to 5432
+  database_name: string     // Required
+  username: string          // Required
+  password: string          // Required
+  ssl_mode?: string         // Defaults to "prefer"
+}
+```
+
+**ConnectionTestResult:**
+```typescript
+{
+  success: boolean
+  message: string
+  latency_ms?: number
+  server_info?: string      // PostgreSQL version
+  error_detail?: string
+}
+```
+
+**TableDiscoveryResponse:**
+```typescript
+{
+  tables: TableInfo[]
+  count: number
+}
+
+interface TableInfo {
+  schema: string
+  name: string
+  columns: ColumnInfo[]
+}
+
+interface ColumnInfo {
+  name: string
+  type: string
+  nullable: boolean
+  primary_key: boolean
+  default?: string
+}
+```
+
+### Pipeline Management (`/api/v1/pipelines`)
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/pipelines` | POST | Create pipeline with table mappings |
+| `/pipelines/:id/start` | POST | Start pipeline |
+
+**CreatePipelineRequest:**
+```typescript
+{
+  name: string
+  source_id: uuid
+  tables?: CreateTableMappingRequest[]
+  config?: Record<string, any>
+}
+
+interface CreateTableMappingRequest {
+  schema?: string           // Defaults to "public"
+  table: string             // Required
+  enabled?: boolean         // Defaults to true
+}
+```
+
+## 2. Existing Frontend Infrastructure
+
+### API Client (`/web/src/lib/api/`)
+- `sourcesApi.create(input)` - Creates source
+- `sourcesApi.testConnection(id)` - Tests connection (returns `{ success, message }`)
+- `sourcesApi.discoverTables(id)` - **Gap:** Returns `string[]` but backend returns full `TableDiscoveryResponse`
+- `pipelinesApi.create(input)` - Creates pipeline
+
+### React Query Hooks (`/web/src/lib/hooks/`)
+- `useSources()` - List sources
+- `useSource(id)` - Get single source
+- `usePipelines()` - List pipelines
+- Pattern: `useQuery` for fetching, `useMutation` for mutations
+
+### UI Components (shadcn/ui)
+- `Form` - react-hook-form wrapper with FormField, FormItem, FormLabel, FormControl, FormMessage
+- `Input`, `Button`, `Card`, `Select`, `Badge`, `Separator`, `Tabs`, `Skeleton`
+- Form validation with `zod`
+
+## 3. Gaps to Address
+
+1. **Frontend API Client:** `discoverTables()` should return full table info with columns
+2. **No Multi-Step Form:** Need step indicator component
+3. **No Test Connection Hook:** Need `useTestConnection()` mutation hook
+
+## 4. Recommended Wizard Flow
+
+```
+Step 1: Welcome
+    ↓
+Step 2: Database Connection Form
+    ↓
+    API: POST /sources (create source)
+    API: POST /sources/:id/test (test connection)
+    ↓
+Step 3: Table Selection
+    ↓
+    API: GET /sources/:id/tables (discover tables)
+    ↓
+Step 4: Review & Configure
+    ↓
+Step 5: Create Pipeline
+    ↓
+    API: POST /pipelines (create with tables)
+    API: POST /pipelines/:id/start (start pipeline)
+    ↓
+Step 6: Success / Watch Sync
+```
+
+## 5. Key Files to Reference
+
+- `web/src/components/scaling/scaling-policy-form.tsx` - Complex form pattern
+- `web/src/app/sources/page.tsx` - Source listing pattern
+- `web/src/lib/api/sources.ts` - API client
+- `web/src/lib/hooks/use-sources.ts` - Query hooks
+- `internal/api/services/source.go` - Backend connection test logic

--- a/docs/plan/12-setup-wizard/02-implementation-plan.md
+++ b/docs/plan/12-setup-wizard/02-implementation-plan.md
@@ -1,0 +1,179 @@
+# Implementation Plan: Issue #12 - Setup Wizard
+
+## Summary
+
+Build a 6-step wizard that guides users through creating their first CDC pipeline. Backend APIs are complete - this is primarily frontend work with minor API client fixes.
+
+## Approach
+
+Create a new `/setup` route with a multi-step wizard component. Each step is a separate component that shares state via a wizard context. The wizard accumulates data through steps and creates resources (source, pipeline) at appropriate points.
+
+## Wizard Steps
+
+| Step | Name | Purpose | API Calls |
+|------|------|---------|-----------|
+| 1 | Welcome | Introduction, explain what they'll accomplish | None |
+| 2 | Connect Database | Enter credentials, test connection | `POST /sources`, `POST /sources/:id/test` |
+| 3 | Select Tables | Browse discovered tables, select which to replicate | `GET /sources/:id/tables` |
+| 4 | Configure | Pipeline name, optional settings | None |
+| 5 | Review | Summary before creation | None |
+| 6 | Success | Create pipeline, show celebration | `POST /pipelines`, `POST /pipelines/:id/start` |
+
+## Files to Create
+
+### API Layer (2 files)
+- `web/src/lib/api/sources.ts` - **Modify** to fix `discoverTables` return type
+- `web/src/lib/hooks/use-setup.ts` - New hooks for wizard (test connection, discover tables)
+
+### Components (8 files)
+- `web/src/components/setup/setup-wizard.tsx` - Main wizard container with step management
+- `web/src/components/setup/wizard-progress.tsx` - Step indicator/progress bar
+- `web/src/components/setup/step-welcome.tsx` - Welcome step
+- `web/src/components/setup/step-connect.tsx` - Database connection form
+- `web/src/components/setup/step-tables.tsx` - Table selection with checkboxes
+- `web/src/components/setup/step-configure.tsx` - Pipeline name and settings
+- `web/src/components/setup/step-review.tsx` - Review summary
+- `web/src/components/setup/step-success.tsx` - Success celebration
+
+### Pages (1 file)
+- `web/src/app/setup/page.tsx` - Setup wizard page
+
+### Types (1 file)
+- `web/src/lib/api/types.ts` - **Modify** to add `TableInfo`, `ColumnInfo`, `TableDiscoveryResponse`
+
+## Component Architecture
+
+```
+SetupWizard (state management)
+├── WizardProgress (step indicator)
+├── StepWelcome
+├── StepConnect
+│   ├── ConnectionForm (credentials input)
+│   └── ConnectionTest (test result display)
+├── StepTables
+│   └── TableSelector (checkbox list with search)
+├── StepConfigure
+│   └── PipelineConfigForm
+├── StepReview
+│   └── ReviewSummary
+└── StepSuccess
+    └── SuccessCelebration
+```
+
+## State Management
+
+Use React Context for wizard state:
+
+```typescript
+interface WizardState {
+  currentStep: number
+  source: {
+    name: string
+    host: string
+    port: number
+    database_name: string
+    username: string
+    password: string
+    ssl_mode: string
+  } | null
+  sourceId: string | null
+  connectionTested: boolean
+  selectedTables: string[]
+  pipelineName: string
+  pipelineId: string | null
+}
+```
+
+## Task Breakdown
+
+### Phase 1: API Layer
+1. Add `TableInfo`, `ColumnInfo`, `TableDiscoveryResponse` types
+2. Fix `sourcesApi.discoverTables()` to return full response
+3. Create `useTestConnection()` mutation hook
+4. Create `useDiscoverTables()` query hook
+
+### Phase 2: Wizard Infrastructure
+5. Create `WizardProgress` step indicator component
+6. Create `SetupWizard` container with step management
+7. Create wizard context and state management
+
+### Phase 3: Wizard Steps
+8. Create `StepWelcome` - intro and getting started
+9. Create `StepConnect` - database connection form with test
+10. Create `StepTables` - table discovery and selection
+11. Create `StepConfigure` - pipeline name and settings
+12. Create `StepReview` - summary before creation
+13. Create `StepSuccess` - celebration and next steps
+
+### Phase 4: Integration
+14. Create `/setup` page
+15. Add setup entry point (first-run detection or manual access)
+
+## UI Design Notes
+
+### Step Indicator
+- Horizontal progress bar with numbered steps
+- Current step highlighted, completed steps checked
+- Step titles below numbers
+
+### Connection Form
+- Card layout with database icon
+- Fields: Host, Port, Database, Username, Password, SSL Mode
+- "Test Connection" button with loading state
+- Success/error feedback with server info on success
+
+### Table Selector
+- Search input at top
+- Checkbox list of tables grouped by schema
+- Show column count per table
+- "Select All" / "Deselect All" buttons
+- Selected count indicator
+
+### Review Summary
+- Card layout showing:
+  - Source details (host, database, user)
+  - Selected tables count
+  - Pipeline name
+- "Create Pipeline" CTA button
+
+### Success Screen
+- Confetti animation or celebration icon
+- "Pipeline created successfully" message
+- "View Pipeline" and "Create Another" buttons
+
+## Validation
+
+### Step 2 (Connect)
+- All fields required
+- Port: 1-65535
+- Host: non-empty
+- Connection must be tested successfully before proceeding
+
+### Step 3 (Tables)
+- At least one table must be selected
+
+### Step 4 (Configure)
+- Pipeline name required, 1-255 chars
+
+## Error Handling
+
+- Connection test failures: Show error message with retry button
+- Table discovery failures: Show error with retry
+- Pipeline creation failures: Show error, allow retry without losing state
+
+## Estimate
+
+~2,500-3,000 LOC (lower than original 6,000 estimate due to existing infrastructure)
+
+## Verification
+
+```bash
+# Build and lint
+cd web && npm run build && npm run lint
+
+# Manual testing
+1. Navigate to /setup
+2. Complete wizard flow end-to-end
+3. Verify pipeline appears in /pipelines
+4. Test error states (wrong credentials, no tables selected)
+```

--- a/docs/plan/12-setup-wizard/99-session-summary.md
+++ b/docs/plan/12-setup-wizard/99-session-summary.md
@@ -1,0 +1,61 @@
+# Session Summary - Issue #12
+
+**Date:** 2026-01-29
+**Branch:** feature/12-setup-wizard
+
+## Progress
+
+- [x] Research complete
+- [x] Plan approved
+- [x] Implementation complete
+- [x] Lint passing
+- [x] Build passing
+
+## Files Changed
+
+| File | Action |
+|------|--------|
+| `web/src/lib/api/types.ts` | Modified - Added TableInfo, ColumnInfo, TableDiscoveryResponse, ConnectionTestResult, CreateTableMappingInput |
+| `web/src/lib/api/sources.ts` | Modified - Fixed discoverTables return type |
+| `web/src/lib/hooks/use-sources.ts` | Modified - Added useDiscoverTables hook |
+| `web/src/components/setup/wizard-progress.tsx` | Created |
+| `web/src/components/setup/setup-wizard.tsx` | Created |
+| `web/src/components/setup/step-welcome.tsx` | Created |
+| `web/src/components/setup/step-connect.tsx` | Created |
+| `web/src/components/setup/step-tables.tsx` | Created |
+| `web/src/components/setup/step-configure.tsx` | Created |
+| `web/src/components/setup/step-review.tsx` | Created |
+| `web/src/components/setup/step-success.tsx` | Created |
+| `web/src/components/ui/checkbox.tsx` | Created (via shadcn) |
+| `web/src/app/setup/page.tsx` | Created |
+
+## Verification
+
+- [x] Lint passes
+- [x] Build passes
+- [x] Setup page route visible at `/setup`
+
+## Implementation Details
+
+### Wizard Flow
+1. **Welcome** - Introduction to Philotes and what the user will accomplish
+2. **Connect Database** - Form to enter PostgreSQL credentials with test connection
+3. **Select Tables** - Table discovery with search, select all, and checkboxes
+4. **Configure** - Pipeline name with smart defaults info
+5. **Review** - Summary of source, tables, and pipeline config
+6. **Success** - Celebration with links to next steps
+
+### Key Features
+- Step progress indicator with checkmarks for completed steps
+- Connection testing with server info display
+- Table discovery with column count and primary key badges
+- Form validation at each step
+- Error handling with retry capability
+- Success celebration with navigation to pipeline
+
+## Notes
+
+- Added `checkbox` component from shadcn/ui
+- Fixed `discoverTables` API to return full `TableDiscoveryResponse` with column info
+- Pipeline creation includes table mappings in a single API call
+- Auto-starts pipeline after creation

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-avatar": "^1.1.11",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
@@ -1398,6 +1399,92 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",

--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import { SetupWizard } from "@/components/setup/setup-wizard"
+
+export default function SetupPage() {
+  return (
+    <div className="container max-w-4xl py-8">
+      <SetupWizard />
+    </div>
+  )
+}

--- a/web/src/components/setup/setup-wizard.tsx
+++ b/web/src/components/setup/setup-wizard.tsx
@@ -1,0 +1,207 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import { useRouter } from "next/navigation"
+import { Card, CardContent } from "@/components/ui/card"
+import { WizardProgress, type WizardStep } from "./wizard-progress"
+import { StepWelcome } from "./step-welcome"
+import { StepConnect } from "./step-connect"
+import { StepTables } from "./step-tables"
+import { StepConfigure } from "./step-configure"
+import { StepReview } from "./step-review"
+import { StepSuccess } from "./step-success"
+import type { Source, TableInfo } from "@/lib/api/types"
+
+const WIZARD_STEPS: WizardStep[] = [
+  { id: 1, title: "Welcome" },
+  { id: 2, title: "Connect" },
+  { id: 3, title: "Tables" },
+  { id: 4, title: "Configure" },
+  { id: 5, title: "Review" },
+  { id: 6, title: "Done" },
+]
+
+export interface SourceFormData {
+  name: string
+  host: string
+  port: number
+  database_name: string
+  username: string
+  password: string
+  ssl_mode: string
+}
+
+export interface WizardState {
+  currentStep: number
+  sourceFormData: SourceFormData
+  source: Source | null
+  connectionTested: boolean
+  availableTables: TableInfo[]
+  selectedTables: string[]
+  pipelineName: string
+  pipelineId: string | null
+}
+
+const initialSourceFormData: SourceFormData = {
+  name: "",
+  host: "",
+  port: 5432,
+  database_name: "",
+  username: "",
+  password: "",
+  ssl_mode: "prefer",
+}
+
+export function SetupWizard() {
+  const router = useRouter()
+  const [state, setState] = useState<WizardState>({
+    currentStep: 1,
+    sourceFormData: initialSourceFormData,
+    source: null,
+    connectionTested: false,
+    availableTables: [],
+    selectedTables: [],
+    pipelineName: "",
+    pipelineId: null,
+  })
+
+  // goToStep can be used for direct navigation if needed in the future
+  // const goToStep = useCallback((step: number) => {
+  //   setState((prev) => ({ ...prev, currentStep: step }))
+  // }, [])
+
+  const nextStep = useCallback(() => {
+    setState((prev) => ({ ...prev, currentStep: Math.min(prev.currentStep + 1, 6) }))
+  }, [])
+
+  const prevStep = useCallback(() => {
+    setState((prev) => ({ ...prev, currentStep: Math.max(prev.currentStep - 1, 1) }))
+  }, [])
+
+  const updateSourceFormData = useCallback((data: Partial<SourceFormData>) => {
+    setState((prev) => ({
+      ...prev,
+      sourceFormData: { ...prev.sourceFormData, ...data },
+    }))
+  }, [])
+
+  const setSource = useCallback((source: Source) => {
+    setState((prev) => ({ ...prev, source }))
+  }, [])
+
+  const setConnectionTested = useCallback((tested: boolean) => {
+    setState((prev) => ({ ...prev, connectionTested: tested }))
+  }, [])
+
+  const setAvailableTables = useCallback((tables: TableInfo[]) => {
+    setState((prev) => ({ ...prev, availableTables: tables }))
+  }, [])
+
+  const setSelectedTables = useCallback((tables: string[]) => {
+    setState((prev) => ({ ...prev, selectedTables: tables }))
+  }, [])
+
+  const setPipelineName = useCallback((name: string) => {
+    setState((prev) => ({ ...prev, pipelineName: name }))
+  }, [])
+
+  const setPipelineId = useCallback((id: string) => {
+    setState((prev) => ({ ...prev, pipelineId: id }))
+  }, [])
+
+  const handleViewPipeline = useCallback(() => {
+    if (state.pipelineId) {
+      router.push(`/pipelines/${state.pipelineId}`)
+    }
+  }, [state.pipelineId, router])
+
+  const handleCreateAnother = useCallback(() => {
+    setState({
+      currentStep: 1,
+      sourceFormData: initialSourceFormData,
+      source: null,
+      connectionTested: false,
+      availableTables: [],
+      selectedTables: [],
+      pipelineName: "",
+      pipelineId: null,
+    })
+  }, [])
+
+  const renderStep = () => {
+    switch (state.currentStep) {
+      case 1:
+        return <StepWelcome onNext={nextStep} />
+      case 2:
+        return (
+          <StepConnect
+            formData={state.sourceFormData}
+            onFormDataChange={updateSourceFormData}
+            source={state.source}
+            onSourceCreated={setSource}
+            connectionTested={state.connectionTested}
+            onConnectionTested={setConnectionTested}
+            onNext={nextStep}
+            onBack={prevStep}
+          />
+        )
+      case 3:
+        return (
+          <StepTables
+            sourceId={state.source?.id ?? ""}
+            availableTables={state.availableTables}
+            onTablesLoaded={setAvailableTables}
+            selectedTables={state.selectedTables}
+            onSelectedTablesChange={setSelectedTables}
+            onNext={nextStep}
+            onBack={prevStep}
+          />
+        )
+      case 4:
+        return (
+          <StepConfigure
+            pipelineName={state.pipelineName}
+            onPipelineNameChange={setPipelineName}
+            sourceName={state.sourceFormData.name}
+            selectedTablesCount={state.selectedTables.length}
+            onNext={nextStep}
+            onBack={prevStep}
+          />
+        )
+      case 5:
+        return (
+          <StepReview
+            sourceFormData={state.sourceFormData}
+            source={state.source}
+            selectedTables={state.selectedTables}
+            pipelineName={state.pipelineName}
+            onPipelineCreated={setPipelineId}
+            onNext={nextStep}
+            onBack={prevStep}
+          />
+        )
+      case 6:
+        return (
+          <StepSuccess
+            pipelineName={state.pipelineName}
+            pipelineId={state.pipelineId ?? ""}
+            onViewPipeline={handleViewPipeline}
+            onCreateAnother={handleCreateAnother}
+          />
+        )
+      default:
+        return null
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <WizardProgress steps={WIZARD_STEPS} currentStep={state.currentStep} />
+      <Card>
+        <CardContent className="pt-6">
+          {renderStep()}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/web/src/components/setup/step-configure.tsx
+++ b/web/src/components/setup/step-configure.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { ArrowLeft, ArrowRight, Settings, Lightbulb } from "lucide-react"
+
+interface StepConfigureProps {
+  pipelineName: string
+  onPipelineNameChange: (name: string) => void
+  sourceName: string
+  selectedTablesCount: number
+  onNext: () => void
+  onBack: () => void
+}
+
+export function StepConfigure({
+  pipelineName,
+  onPipelineNameChange,
+  sourceName,
+  selectedTablesCount,
+  onNext,
+  onBack,
+}: StepConfigureProps) {
+  const suggestedName = sourceName ? `${sourceName} Pipeline` : ""
+
+  const handleUseSuggestion = () => {
+    onPipelineNameChange(suggestedName)
+  }
+
+  const isValid = pipelineName.trim().length > 0 && pipelineName.length <= 255
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Settings className="h-5 w-5 text-primary" />
+          <h2 className="text-xl font-semibold">Configure Your Pipeline</h2>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Give your pipeline a name. You can adjust additional settings later.
+        </p>
+      </div>
+
+      {/* Summary */}
+      <div className="bg-muted/50 rounded-lg p-4 space-y-2">
+        <p className="text-sm">
+          <span className="text-muted-foreground">Source:</span>{" "}
+          <span className="font-medium">{sourceName || "Unknown"}</span>
+        </p>
+        <p className="text-sm">
+          <span className="text-muted-foreground">Tables to replicate:</span>{" "}
+          <span className="font-medium">{selectedTablesCount}</span>
+        </p>
+      </div>
+
+      {/* Pipeline Name */}
+      <div className="space-y-2">
+        <Label htmlFor="pipeline_name">Pipeline Name</Label>
+        <Input
+          id="pipeline_name"
+          placeholder="e.g., Production CDC Pipeline"
+          value={pipelineName}
+          onChange={(e) => onPipelineNameChange(e.target.value)}
+          maxLength={255}
+        />
+        <p className="text-xs text-muted-foreground">
+          A descriptive name to identify this replication pipeline
+        </p>
+        {suggestedName && pipelineName !== suggestedName && (
+          <button
+            type="button"
+            onClick={handleUseSuggestion}
+            className="flex items-center gap-1 text-xs text-primary hover:underline"
+          >
+            <Lightbulb className="h-3 w-3" />
+            Suggestion: {suggestedName}
+          </button>
+        )}
+      </div>
+
+      {/* Smart Defaults Info */}
+      <div className="bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+        <h3 className="font-medium text-blue-800 dark:text-blue-200 mb-2">
+          Smart Defaults Applied
+        </h3>
+        <ul className="text-sm text-blue-700 dark:text-blue-300 space-y-1">
+          <li>- Batch size: 1,000 events</li>
+          <li>- Flush interval: 10 seconds</li>
+          <li>- Checkpoint frequency: 30 seconds</li>
+          <li>- Automatic retry on failures</li>
+        </ul>
+        <p className="text-xs text-blue-600 dark:text-blue-400 mt-2">
+          These settings work well for most use cases. You can customize them after creation.
+        </p>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between pt-4">
+        <Button variant="outline" onClick={onBack}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back
+        </Button>
+        <Button onClick={onNext} disabled={!isValid}>
+          Review & Create
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/setup/step-connect.tsx
+++ b/web/src/components/setup/step-connect.tsx
@@ -1,0 +1,290 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Badge } from "@/components/ui/badge"
+import { ArrowLeft, ArrowRight, Database, CheckCircle2, XCircle, Loader2 } from "lucide-react"
+import { useCreateSource, useTestSourceConnection } from "@/lib/hooks/use-sources"
+import type { Source } from "@/lib/api/types"
+import type { SourceFormData } from "./setup-wizard"
+
+interface StepConnectProps {
+  formData: SourceFormData
+  onFormDataChange: (data: Partial<SourceFormData>) => void
+  source: Source | null
+  onSourceCreated: (source: Source) => void
+  connectionTested: boolean
+  onConnectionTested: (tested: boolean) => void
+  onNext: () => void
+  onBack: () => void
+}
+
+const SSL_MODE_OPTIONS = [
+  { value: "disable", label: "Disable" },
+  { value: "prefer", label: "Prefer (default)" },
+  { value: "require", label: "Require" },
+  { value: "verify-ca", label: "Verify CA" },
+  { value: "verify-full", label: "Verify Full" },
+]
+
+export function StepConnect({
+  formData,
+  onFormDataChange,
+  source,
+  onSourceCreated,
+  connectionTested,
+  onConnectionTested,
+  onNext,
+  onBack,
+}: StepConnectProps) {
+  const [testResult, setTestResult] = useState<{
+    success: boolean
+    message: string
+    serverInfo?: string
+  } | null>(null)
+
+  const createSource = useCreateSource()
+  const testConnection = useTestSourceConnection()
+
+  const isFormValid =
+    formData.name.trim() !== "" &&
+    formData.host.trim() !== "" &&
+    formData.database_name.trim() !== "" &&
+    formData.username.trim() !== "" &&
+    formData.password.trim() !== "" &&
+    formData.port > 0 &&
+    formData.port <= 65535
+
+  const handleTestConnection = async () => {
+    if (!isFormValid) return
+
+    setTestResult(null)
+    onConnectionTested(false)
+
+    try {
+      // First create the source if it doesn't exist
+      let currentSource = source
+      if (!currentSource) {
+        currentSource = await createSource.mutateAsync({
+          name: formData.name,
+          type: "postgresql",
+          host: formData.host,
+          port: formData.port,
+          database_name: formData.database_name,
+          username: formData.username,
+          password: formData.password,
+          ssl_mode: formData.ssl_mode,
+        })
+        onSourceCreated(currentSource)
+      }
+
+      // Then test the connection
+      const result = await testConnection.mutateAsync(currentSource.id)
+      setTestResult({
+        success: result.success,
+        message: result.message,
+        serverInfo: result.server_info,
+      })
+      onConnectionTested(result.success)
+    } catch (error) {
+      setTestResult({
+        success: false,
+        message: error instanceof Error ? error.message : "Connection failed",
+      })
+      onConnectionTested(false)
+    }
+  }
+
+  const isLoading = createSource.isPending || testConnection.isPending
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Database className="h-5 w-5 text-primary" />
+          <h2 className="text-xl font-semibold">Connect Your Database</h2>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Enter your PostgreSQL database credentials. We&apos;ll test the connection before proceeding.
+        </p>
+      </div>
+
+      {/* Form */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        {/* Source Name */}
+        <div className="sm:col-span-2">
+          <Label htmlFor="name">Source Name</Label>
+          <Input
+            id="name"
+            placeholder="e.g., Production Database"
+            value={formData.name}
+            onChange={(e) => onFormDataChange({ name: e.target.value })}
+            className="mt-1"
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            A friendly name to identify this database connection
+          </p>
+        </div>
+
+        {/* Host */}
+        <div>
+          <Label htmlFor="host">Host</Label>
+          <Input
+            id="host"
+            placeholder="localhost or db.example.com"
+            value={formData.host}
+            onChange={(e) => onFormDataChange({ host: e.target.value })}
+            className="mt-1"
+          />
+        </div>
+
+        {/* Port */}
+        <div>
+          <Label htmlFor="port">Port</Label>
+          <Input
+            id="port"
+            type="number"
+            placeholder="5432"
+            value={formData.port}
+            onChange={(e) => onFormDataChange({ port: parseInt(e.target.value) || 5432 })}
+            className="mt-1"
+            min={1}
+            max={65535}
+          />
+        </div>
+
+        {/* Database Name */}
+        <div>
+          <Label htmlFor="database_name">Database Name</Label>
+          <Input
+            id="database_name"
+            placeholder="myapp"
+            value={formData.database_name}
+            onChange={(e) => onFormDataChange({ database_name: e.target.value })}
+            className="mt-1"
+          />
+        </div>
+
+        {/* SSL Mode */}
+        <div>
+          <Label htmlFor="ssl_mode">SSL Mode</Label>
+          <Select
+            value={formData.ssl_mode}
+            onValueChange={(value) => onFormDataChange({ ssl_mode: value })}
+          >
+            <SelectTrigger className="mt-1">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SSL_MODE_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Username */}
+        <div>
+          <Label htmlFor="username">Username</Label>
+          <Input
+            id="username"
+            placeholder="postgres"
+            value={formData.username}
+            onChange={(e) => onFormDataChange({ username: e.target.value })}
+            className="mt-1"
+          />
+        </div>
+
+        {/* Password */}
+        <div>
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            placeholder="********"
+            value={formData.password}
+            onChange={(e) => onFormDataChange({ password: e.target.value })}
+            className="mt-1"
+          />
+        </div>
+      </div>
+
+      {/* Test Connection Result */}
+      {testResult && (
+        <div
+          className={`flex items-start gap-3 p-4 rounded-lg ${
+            testResult.success
+              ? "bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800"
+              : "bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800"
+          }`}
+        >
+          {testResult.success ? (
+            <CheckCircle2 className="h-5 w-5 text-green-600 dark:text-green-400 shrink-0 mt-0.5" />
+          ) : (
+            <XCircle className="h-5 w-5 text-red-600 dark:text-red-400 shrink-0 mt-0.5" />
+          )}
+          <div className="space-y-1">
+            <p
+              className={`text-sm font-medium ${
+                testResult.success
+                  ? "text-green-800 dark:text-green-200"
+                  : "text-red-800 dark:text-red-200"
+              }`}
+            >
+              {testResult.message}
+            </p>
+            {testResult.serverInfo && (
+              <p className="text-xs text-muted-foreground">{testResult.serverInfo}</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center justify-between pt-4">
+        <Button variant="outline" onClick={onBack}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back
+        </Button>
+        <div className="flex items-center gap-2">
+          {connectionTested && (
+            <Badge variant="outline" className="text-green-600">
+              <CheckCircle2 className="mr-1 h-3 w-3" />
+              Connected
+            </Badge>
+          )}
+          <Button
+            variant="outline"
+            onClick={handleTestConnection}
+            disabled={!isFormValid || isLoading}
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Testing...
+              </>
+            ) : (
+              "Test Connection"
+            )}
+          </Button>
+          <Button onClick={onNext} disabled={!connectionTested}>
+            Continue
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/setup/step-review.tsx
+++ b/web/src/components/setup/step-review.tsx
@@ -1,0 +1,195 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { ArrowLeft, Rocket, Loader2, Database, Table, GitBranch } from "lucide-react"
+import { useCreatePipeline, useStartPipeline } from "@/lib/hooks/use-pipelines"
+import type { Source } from "@/lib/api/types"
+import type { SourceFormData } from "./setup-wizard"
+
+interface StepReviewProps {
+  sourceFormData: SourceFormData
+  source: Source | null
+  selectedTables: string[]
+  pipelineName: string
+  onPipelineCreated: (id: string) => void
+  onNext: () => void
+  onBack: () => void
+}
+
+export function StepReview({
+  sourceFormData,
+  source,
+  selectedTables,
+  pipelineName,
+  onPipelineCreated,
+  onNext,
+  onBack,
+}: StepReviewProps) {
+  const [error, setError] = useState<string | null>(null)
+  const createPipeline = useCreatePipeline()
+  const startPipeline = useStartPipeline()
+
+  const handleCreate = async () => {
+    if (!source) {
+      setError("Source not found")
+      return
+    }
+
+    setError(null)
+
+    try {
+      // Create pipeline with table mappings
+      const tableMappings = selectedTables.map((fullName) => {
+        const [schema, table] = fullName.split(".")
+        return {
+          schema: schema || "public",
+          table: table,
+          enabled: true,
+        }
+      })
+
+      const pipeline = await createPipeline.mutateAsync({
+        name: pipelineName,
+        source_id: source.id,
+        tables: tableMappings,
+      })
+
+      onPipelineCreated(pipeline.id)
+
+      // Start the pipeline
+      await startPipeline.mutateAsync(pipeline.id)
+
+      onNext()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create pipeline")
+    }
+  }
+
+  const isLoading = createPipeline.isPending || startPipeline.isPending
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Rocket className="h-5 w-5 text-primary" />
+          <h2 className="text-xl font-semibold">Review & Create</h2>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Review your configuration before creating the pipeline.
+        </p>
+      </div>
+
+      {/* Configuration Summary */}
+      <div className="space-y-4">
+        {/* Source Details */}
+        <div className="rounded-lg border p-4 space-y-3">
+          <div className="flex items-center gap-2">
+            <Database className="h-4 w-4 text-primary" />
+            <h3 className="font-medium">Source Database</h3>
+          </div>
+          <div className="grid gap-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Name</span>
+              <span className="font-medium">{sourceFormData.name}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Host</span>
+              <span className="font-mono text-xs">
+                {sourceFormData.host}:{sourceFormData.port}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Database</span>
+              <span>{sourceFormData.database_name}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">User</span>
+              <span>{sourceFormData.username}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">SSL</span>
+              <Badge variant="outline" className="text-xs">
+                {sourceFormData.ssl_mode}
+              </Badge>
+            </div>
+          </div>
+        </div>
+
+        {/* Tables */}
+        <div className="rounded-lg border p-4 space-y-3">
+          <div className="flex items-center gap-2">
+            <Table className="h-4 w-4 text-primary" />
+            <h3 className="font-medium">
+              Tables ({selectedTables.length})
+            </h3>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {selectedTables.slice(0, 10).map((table) => (
+              <Badge key={table} variant="secondary" className="font-mono text-xs">
+                {table}
+              </Badge>
+            ))}
+            {selectedTables.length > 10 && (
+              <Badge variant="outline" className="text-xs">
+                +{selectedTables.length - 10} more
+              </Badge>
+            )}
+          </div>
+        </div>
+
+        {/* Pipeline */}
+        <div className="rounded-lg border p-4 space-y-3">
+          <div className="flex items-center gap-2">
+            <GitBranch className="h-4 w-4 text-primary" />
+            <h3 className="font-medium">Pipeline</h3>
+          </div>
+          <div className="grid gap-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Name</span>
+              <span className="font-medium">{pipelineName}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Destination</span>
+              <span>Apache Iceberg</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Auto-start</span>
+              <Badge variant="outline" className="text-xs">Yes</Badge>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="bg-destructive/10 text-destructive rounded-lg p-4 text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center justify-between pt-4">
+        <Button variant="outline" onClick={onBack} disabled={isLoading}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back
+        </Button>
+        <Button onClick={handleCreate} disabled={isLoading}>
+          {isLoading ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Creating...
+            </>
+          ) : (
+            <>
+              <Rocket className="mr-2 h-4 w-4" />
+              Create Pipeline
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/setup/step-success.tsx
+++ b/web/src/components/setup/step-success.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { CheckCircle2, ArrowRight, Plus, ExternalLink } from "lucide-react"
+
+interface StepSuccessProps {
+  pipelineName: string
+  pipelineId: string
+  onViewPipeline: () => void
+  onCreateAnother: () => void
+}
+
+export function StepSuccess({
+  pipelineName,
+  onViewPipeline,
+  onCreateAnother,
+}: StepSuccessProps) {
+  return (
+    <div className="space-y-8 py-8">
+      {/* Success Icon */}
+      <div className="flex justify-center">
+        <div className="rounded-full bg-green-100 dark:bg-green-900/30 p-6">
+          <CheckCircle2 className="h-16 w-16 text-green-600 dark:text-green-400" />
+        </div>
+      </div>
+
+      {/* Message */}
+      <div className="text-center space-y-2">
+        <h2 className="text-2xl font-bold text-green-700 dark:text-green-300">
+          Pipeline Created Successfully!
+        </h2>
+        <p className="text-muted-foreground max-w-md mx-auto">
+          Your pipeline <span className="font-medium">{pipelineName}</span> has been
+          created and is now running. Data will start flowing to your Iceberg tables
+          shortly.
+        </p>
+      </div>
+
+      {/* What's happening */}
+      <div className="bg-muted/50 rounded-lg p-4 max-w-md mx-auto">
+        <h3 className="font-medium mb-2">What&apos;s happening now:</h3>
+        <ul className="text-sm text-muted-foreground space-y-1">
+          <li>1. Connecting to your PostgreSQL database</li>
+          <li>2. Creating replication slot for CDC</li>
+          <li>3. Performing initial table snapshots</li>
+          <li>4. Streaming changes to Iceberg in real-time</li>
+        </ul>
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+        <Button size="lg" onClick={onViewPipeline}>
+          View Pipeline
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Button>
+        <Button variant="outline" size="lg" onClick={onCreateAnother}>
+          <Plus className="mr-2 h-4 w-4" />
+          Create Another
+        </Button>
+      </div>
+
+      {/* Next steps */}
+      <div className="text-center">
+        <h3 className="font-medium mb-2">Next steps:</h3>
+        <div className="flex flex-wrap justify-center gap-4 text-sm">
+          <Link
+            href="/pipelines"
+            className="flex items-center gap-1 text-primary hover:underline"
+          >
+            Monitor all pipelines
+            <ExternalLink className="h-3 w-3" />
+          </Link>
+          <Link
+            href="/scaling"
+            className="flex items-center gap-1 text-primary hover:underline"
+          >
+            Configure auto-scaling
+            <ExternalLink className="h-3 w-3" />
+          </Link>
+          <Link
+            href="/sources"
+            className="flex items-center gap-1 text-primary hover:underline"
+          >
+            Manage sources
+            <ExternalLink className="h-3 w-3" />
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/setup/step-tables.tsx
+++ b/web/src/components/setup/step-tables.tsx
@@ -1,0 +1,220 @@
+"use client"
+
+import { useState, useEffect, useMemo } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { ArrowLeft, ArrowRight, Table, Search, Columns, Key } from "lucide-react"
+import { useDiscoverTables } from "@/lib/hooks/use-sources"
+import type { TableInfo } from "@/lib/api/types"
+
+interface StepTablesProps {
+  sourceId: string
+  availableTables: TableInfo[]
+  onTablesLoaded: (tables: TableInfo[]) => void
+  selectedTables: string[]
+  onSelectedTablesChange: (tables: string[]) => void
+  onNext: () => void
+  onBack: () => void
+}
+
+export function StepTables({
+  sourceId,
+  availableTables,
+  onTablesLoaded,
+  selectedTables,
+  onSelectedTablesChange,
+  onNext,
+  onBack,
+}: StepTablesProps) {
+  const [searchQuery, setSearchQuery] = useState("")
+  const { data, isLoading, error } = useDiscoverTables(sourceId)
+
+  // Update available tables when data loads
+  useEffect(() => {
+    if (data?.tables && data.tables.length > 0) {
+      onTablesLoaded(data.tables)
+    }
+  }, [data, onTablesLoaded])
+
+  // Memoize tables to prevent unnecessary re-renders
+  const tables = useMemo(() => {
+    return availableTables.length > 0 ? availableTables : data?.tables ?? []
+  }, [availableTables, data?.tables])
+
+  // Filter tables based on search query
+  const filteredTables = useMemo(() => {
+    if (!searchQuery.trim()) return tables
+    const query = searchQuery.toLowerCase()
+    return tables.filter(
+      (table) =>
+        table.name.toLowerCase().includes(query) ||
+        table.schema.toLowerCase().includes(query)
+    )
+  }, [tables, searchQuery])
+
+  const handleToggleTable = (table: TableInfo) => {
+    const fullName = `${table.schema}.${table.name}`
+    if (selectedTables.includes(fullName)) {
+      onSelectedTablesChange(selectedTables.filter((t) => t !== fullName))
+    } else {
+      onSelectedTablesChange([...selectedTables, fullName])
+    }
+  }
+
+  const handleSelectAll = () => {
+    const allTableNames = filteredTables.map((t) => `${t.schema}.${t.name}`)
+    onSelectedTablesChange(allTableNames)
+  }
+
+  const handleDeselectAll = () => {
+    onSelectedTablesChange([])
+  }
+
+  const isTableSelected = (table: TableInfo) => {
+    return selectedTables.includes(`${table.schema}.${table.name}`)
+  }
+
+  const getPrimaryKeyColumns = (table: TableInfo) => {
+    return table.columns.filter((col) => col.primary_key).map((col) => col.name)
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-72" />
+        </div>
+        <Skeleton className="h-10 w-full" />
+        <div className="space-y-2">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <Skeleton key={i} className="h-16 w-full" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <div className="text-center py-8">
+          <p className="text-destructive">Failed to discover tables: {error.message}</p>
+          <Button variant="outline" onClick={onBack} className="mt-4">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Go Back
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Table className="h-5 w-5 text-primary" />
+          <h2 className="text-xl font-semibold">Select Tables to Replicate</h2>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Choose which tables you want to replicate to your data lake.
+          {tables.length > 0 && ` Found ${tables.length} tables.`}
+        </p>
+      </div>
+
+      {/* Search and actions */}
+      <div className="flex items-center gap-4">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search tables..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={handleSelectAll}>
+            Select All
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleDeselectAll}>
+            Deselect All
+          </Button>
+        </div>
+      </div>
+
+      {/* Selected count */}
+      {selectedTables.length > 0 && (
+        <div className="text-sm text-muted-foreground">
+          {selectedTables.length} table{selectedTables.length !== 1 ? "s" : ""} selected
+        </div>
+      )}
+
+      {/* Table list */}
+      <div className="space-y-2 max-h-[400px] overflow-y-auto">
+        {filteredTables.length === 0 ? (
+          <div className="text-center py-8 text-muted-foreground">
+            {searchQuery ? "No tables match your search" : "No tables found"}
+          </div>
+        ) : (
+          filteredTables.map((table) => {
+            const primaryKeys = getPrimaryKeyColumns(table)
+            const isSelected = isTableSelected(table)
+
+            return (
+              <div
+                key={`${table.schema}.${table.name}`}
+                className={`flex items-start gap-3 p-4 rounded-lg border cursor-pointer transition-colors ${
+                  isSelected
+                    ? "bg-primary/5 border-primary/50"
+                    : "bg-card hover:bg-muted/50"
+                }`}
+                onClick={() => handleToggleTable(table)}
+              >
+                <Checkbox
+                  checked={isSelected}
+                  onCheckedChange={() => handleToggleTable(table)}
+                  className="mt-1"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <Label className="font-medium cursor-pointer">
+                      {table.schema}.{table.name}
+                    </Label>
+                    {primaryKeys.length > 0 && (
+                      <Badge variant="outline" className="text-xs">
+                        <Key className="mr-1 h-3 w-3" />
+                        {primaryKeys.join(", ")}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1 mt-1 text-xs text-muted-foreground">
+                    <Columns className="h-3 w-3" />
+                    <span>{table.columns.length} columns</span>
+                  </div>
+                </div>
+              </div>
+            )
+          })
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between pt-4">
+        <Button variant="outline" onClick={onBack}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back
+        </Button>
+        <Button onClick={onNext} disabled={selectedTables.length === 0}>
+          Continue
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/setup/step-welcome.tsx
+++ b/web/src/components/setup/step-welcome.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Database, ArrowRight, GitBranch, Table, Zap } from "lucide-react"
+
+interface StepWelcomeProps {
+  onNext: () => void
+}
+
+export function StepWelcome({ onNext }: StepWelcomeProps) {
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="text-center space-y-4">
+        <div className="flex justify-center">
+          <div className="rounded-full bg-primary/10 p-4">
+            <Zap className="h-12 w-12 text-primary" />
+          </div>
+        </div>
+        <h2 className="text-2xl font-bold">Welcome to Philotes</h2>
+        <p className="text-muted-foreground max-w-md mx-auto">
+          Set up your first CDC pipeline in just a few minutes. We&apos;ll guide you
+          through connecting your database and selecting tables to replicate.
+        </p>
+      </div>
+
+      {/* What you'll do */}
+      <div className="grid gap-4 sm:grid-cols-3 max-w-2xl mx-auto">
+        <div className="flex flex-col items-center text-center p-4 rounded-lg border bg-card">
+          <Database className="h-8 w-8 text-primary mb-2" />
+          <h3 className="font-medium">Connect Database</h3>
+          <p className="text-sm text-muted-foreground">
+            Enter your PostgreSQL credentials
+          </p>
+        </div>
+        <div className="flex flex-col items-center text-center p-4 rounded-lg border bg-card">
+          <Table className="h-8 w-8 text-primary mb-2" />
+          <h3 className="font-medium">Select Tables</h3>
+          <p className="text-sm text-muted-foreground">
+            Choose which tables to replicate
+          </p>
+        </div>
+        <div className="flex flex-col items-center text-center p-4 rounded-lg border bg-card">
+          <GitBranch className="h-8 w-8 text-primary mb-2" />
+          <h3 className="font-medium">Start Pipeline</h3>
+          <p className="text-sm text-muted-foreground">
+            Watch your data flow to Iceberg
+          </p>
+        </div>
+      </div>
+
+      {/* What you'll need */}
+      <div className="bg-muted/50 rounded-lg p-4 max-w-md mx-auto">
+        <h3 className="font-medium mb-2">What you&apos;ll need:</h3>
+        <ul className="text-sm text-muted-foreground space-y-1">
+          <li>- PostgreSQL database hostname and port</li>
+          <li>- Database username and password</li>
+          <li>- User with SELECT and REPLICATION permissions</li>
+        </ul>
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-center">
+        <Button size="lg" onClick={onNext}>
+          Get Started
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/setup/wizard-progress.tsx
+++ b/web/src/components/setup/wizard-progress.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { Check } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+export interface WizardStep {
+  id: number
+  title: string
+}
+
+interface WizardProgressProps {
+  steps: WizardStep[]
+  currentStep: number
+  className?: string
+}
+
+export function WizardProgress({ steps, currentStep, className }: WizardProgressProps) {
+  return (
+    <div className={cn("w-full", className)}>
+      <div className="flex items-center justify-between">
+        {steps.map((step, index) => {
+          const isCompleted = step.id < currentStep
+          const isCurrent = step.id === currentStep
+          const isLast = index === steps.length - 1
+
+          return (
+            <div key={step.id} className="flex items-center flex-1 last:flex-none">
+              {/* Step circle */}
+              <div className="flex flex-col items-center">
+                <div
+                  className={cn(
+                    "flex h-10 w-10 items-center justify-center rounded-full border-2 text-sm font-medium transition-colors",
+                    isCompleted && "border-primary bg-primary text-primary-foreground",
+                    isCurrent && "border-primary bg-background text-primary",
+                    !isCompleted && !isCurrent && "border-muted bg-background text-muted-foreground"
+                  )}
+                >
+                  {isCompleted ? (
+                    <Check className="h-5 w-5" />
+                  ) : (
+                    step.id
+                  )}
+                </div>
+                <span
+                  className={cn(
+                    "mt-2 text-xs font-medium",
+                    isCurrent && "text-primary",
+                    !isCurrent && "text-muted-foreground"
+                  )}
+                >
+                  {step.title}
+                </span>
+              </div>
+
+              {/* Connector line */}
+              {!isLast && (
+                <div
+                  className={cn(
+                    "h-0.5 flex-1 mx-2 transition-colors",
+                    isCompleted ? "bg-primary" : "bg-muted"
+                  )}
+                />
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/web/src/lib/api/sources.ts
+++ b/web/src/lib/api/sources.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "./client"
-import type { Source, CreateSourceInput } from "./types"
+import type { Source, CreateSourceInput, TableDiscoveryResponse, ConnectionTestResult } from "./types"
 
 export const sourcesApi = {
   /**
@@ -40,8 +40,8 @@ export const sourcesApi = {
   /**
    * Test source connection
    */
-  testConnection(id: string): Promise<{ success: boolean; message: string }> {
-    return apiClient.post<{ success: boolean; message: string }>(
+  testConnection(id: string): Promise<ConnectionTestResult> {
+    return apiClient.post<ConnectionTestResult>(
       `/api/v1/sources/${id}/test`
     )
   },
@@ -49,7 +49,8 @@ export const sourcesApi = {
   /**
    * Discover tables from source
    */
-  discoverTables(id: string): Promise<string[]> {
-    return apiClient.get<string[]>(`/api/v1/sources/${id}/tables`)
+  discoverTables(id: string, schema?: string): Promise<TableDiscoveryResponse> {
+    const params = schema ? `?schema=${encodeURIComponent(schema)}` : ""
+    return apiClient.get<TableDiscoveryResponse>(`/api/v1/sources/${id}/tables${params}`)
   },
 }

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -29,6 +29,35 @@ export interface CreateSourceInput {
   ssl_mode?: string
 }
 
+// Table Discovery Types
+
+export interface ColumnInfo {
+  name: string
+  type: string
+  nullable: boolean
+  primary_key: boolean
+  default?: string
+}
+
+export interface TableInfo {
+  schema: string
+  name: string
+  columns: ColumnInfo[]
+}
+
+export interface TableDiscoveryResponse {
+  tables: TableInfo[]
+  count: number
+}
+
+export interface ConnectionTestResult {
+  success: boolean
+  message: string
+  latency_ms?: number
+  server_info?: string
+  error_detail?: string
+}
+
 export interface TableMapping {
   id: string
   source_table: string
@@ -51,9 +80,17 @@ export interface Pipeline {
   stopped_at?: string
 }
 
+export interface CreateTableMappingInput {
+  schema?: string
+  table: string
+  enabled?: boolean
+  config?: Record<string, unknown>
+}
+
 export interface CreatePipelineInput {
   name: string
   source_id: string
+  tables?: CreateTableMappingInput[]
   config?: Record<string, unknown>
 }
 

--- a/web/src/lib/hooks/use-sources.ts
+++ b/web/src/lib/hooks/use-sources.ts
@@ -56,3 +56,11 @@ export function useTestSourceConnection() {
     mutationFn: (id: string) => sourcesApi.testConnection(id),
   })
 }
+
+export function useDiscoverTables(sourceId: string, schema?: string) {
+  return useQuery({
+    queryKey: ["sources", sourceId, "tables", schema],
+    queryFn: () => sourcesApi.discoverTables(sourceId, schema),
+    enabled: !!sourceId,
+  })
+}


### PR DESCRIPTION
## Summary

Implements a 6-step setup wizard that guides new users through creating their first CDC pipeline (Issue #12).

- **Step 1: Welcome** - Introduction to Philotes and what users will accomplish
- **Step 2: Connect** - Database credentials form with connection test
- **Step 3: Tables** - Table discovery with search, select all, and primary key display
- **Step 4: Configure** - Pipeline name with smart defaults info
- **Step 5: Review** - Summary of source, tables, and pipeline config
- **Step 6: Success** - Celebration with links to next steps

Also includes:
- Fix `discoverTables` API to return full `TableDiscoveryResponse` with column info
- Add `useDiscoverTables` hook
- Add `checkbox` component from shadcn/ui
- Add `TableInfo`, `ColumnInfo`, `TableDiscoveryResponse`, `ConnectionTestResult` types

## Test plan

- [ ] Navigate to /setup
- [ ] Enter database credentials and test connection
- [ ] Select tables from discovered list
- [ ] Enter pipeline name
- [ ] Review configuration and create pipeline
- [ ] Verify pipeline appears in /pipelines
- [ ] Test error states (wrong credentials, no tables selected)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)